### PR TITLE
Scheduling fixed

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -44,7 +44,7 @@
         payload.args = args;
         payload.jid = jid;
         if (payload.at instanceof Date) {
-          payloat.at = payload.at.getTime() / 1000;
+          payload.at = payload.at.getTime() / 1000;
           return _this.redisConnection.zadd(_this.namespaceKey("schedule"), payload.at, JSON.stringify(payload));
         } else {
           _this.redisConnection.lpush(_this.getQueueKey(payload.queue), JSON.stringify(payload));

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -25,7 +25,7 @@ class Sidekiq
       payload.jid = jid
 
       if payload.at instanceof Date
-        payloat.at = payload.at.getTime() / 1000
+        payload.at = payload.at.getTime() / 1000
         # Push job payload to schedule
         @redisConnection.zadd @namespaceKey("schedule"), payload.at, JSON.stringify(payload)
       else


### PR DESCRIPTION
Using the module, an error pop up in the worker:

```
2014-01-25T19:25:01Z 40935 TID-zq5lo4 ERROR: ERR value is not a valid float
2014-01-25T19:25:01Z 40935 TID-zq5lo4 ERROR: /Users/jam/.rvm/gems/ruby-2.1.0/gems/redis-3.0.7/lib/redis/client.rb:97:in `call'
```

After doing some tests, sidekiq needs the date in epoch, so I changed it.

Thanks for this useful module!
