### PR TITLE
Added 'enqueued_at' property to payloads.

### DIFF
--- a/src/index.coffee
+++ b/src/index.coffee
@@ -30,6 +30,8 @@ class Sidekiq
         # Push job payload to schedule
         @redisConnection.zadd @namespaceKey("schedule"), payload.at, JSON.stringify(payload), cb
       else
+        # Add enqueued_at dat to payload
+        payload.enqueued_at = new Date().getTime() / 1000
         # Push job payload to redis
         @redisConnection.lpush @getQueueKey(payload.queue), JSON.stringify(payload), (err) =>
           if err


### PR DESCRIPTION
When a job is enqueued, there should be a enqueued_at property with the time the job was enqueued as a float. Sidekiq expects this field, for example, to calculate the default queue latency and will raise an error if it is not present.