### PR TITLE
Added jid to returned values

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -44,13 +44,24 @@ Sidekiq = (function() {
         payload.jid = jid;
         if (payload.at instanceof Date) {
           payload.at = payload.at.getTime() / 1000;
-          return _this.redisConnection.zadd(_this.namespaceKey("schedule"), payload.at, JSON.stringify(payload), cb);
+          return _this.redisConnection.zadd(_this.namespaceKey("schedule"), payload.at, JSON.stringify(payload), function(err, response) {
+            if (err) {
+              return cb(err);
+            }
+            return cb(null, response, jid);
+          });
         } else {
+          payload.enqueued_at = new Date().getTime() / 1000;
           return _this.redisConnection.lpush(_this.getQueueKey(payload.queue), JSON.stringify(payload), function(err) {
             if (err) {
               return cb(err);
             } else {
-              return _this.redisConnection.sadd(_this.namespaceKey("queues"), getQueueName(payload.queue), cb);
+              return _this.redisConnection.sadd(_this.namespaceKey("queues"), getQueueName(payload.queue), function(err, response) {
+                if (err) {
+                  return cb(err);
+                }
+                return cb(null, response, jid);
+              });
             }
           });
         }

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -28,7 +28,9 @@ class Sidekiq
       if payload.at instanceof Date
         payload.at = payload.at.getTime() / 1000
         # Push job payload to schedule
-        @redisConnection.zadd @namespaceKey("schedule"), payload.at, JSON.stringify(payload), cb
+        @redisConnection.zadd @namespaceKey("schedule"), payload.at, JSON.stringify(payload), (err, response) ->
+          return cb(err) if err
+          cb(null, response, jid)
       else
         # Add enqueued_at dat to payload
         payload.enqueued_at = new Date().getTime() / 1000
@@ -38,6 +40,8 @@ class Sidekiq
             cb(err)
           else
             # Create the queue if it doesn't already exist
-            @redisConnection.sadd @namespaceKey("queues"), getQueueName(payload.queue), cb
+            @redisConnection.sadd @namespaceKey("queues"), getQueueName(payload.queue), (err, response) ->
+              return cb(err) if err
+              cb(null, response, jid)
 
   module.exports = Sidekiq


### PR DESCRIPTION
I've found it useful to know `jid` of enqueued jobs.

Redis [SADD](http://redis.io/commands/sadd#return-value) and [ZADD](http://redis.io/commands/ZADD#return-value) methods returns only a number of elements that were added to the set. That's the value which was returned in callback by `enqueue` method. It is still available in `response`, but now you can get `jid` besides that.
