### PR TITLE
Update redis version to ~2.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,6 @@
         "grunt-bumpx": "~0.1.0"
     },
     "dependencies": {
-        "redis": "~0.8"
+        "redis": "~2.8"
     }
 }


### PR DESCRIPTION
I wanted to initialize using a Redis URL, `redis.createClient(redis_url[, options])`, as seen on https://www.npmjs.com/package/redis. It took me a while to realize this package is using a very old version that didn't support it.